### PR TITLE
Don't deactivate the server extension

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
 

--- a/recipe/pre-unlink.bat
+++ b/recipe/pre-unlink.bat
@@ -1,3 +1,1 @@
 @echo off
-
-"%PREFIX%\Scripts\jupyter.exe" serverextension disable jupyterlab_git --py --sys-prefix > "%PREFIX%\.messages.txt" 2>&1 && if errorlevel 1 exit 1

--- a/recipe/pre-unlink.sh
+++ b/recipe/pre-unlink.sh
@@ -1,1 +1,0 @@
-"${PREFIX}/bin/jupyter" serverextension disable jupyterlab_git --py --sys-prefix > "${PREFIX}/.messages.txt" 2>&1


### PR DESCRIPTION
Do not disable the server extension in the pre-unlink stage because this can lead to the server extension being disabled when updating.