### PR TITLE
Restrict jupyterlab on < 4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 2
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps --install-option="--skip-npm" -vv
 
@@ -23,6 +23,7 @@ requirements:
     - jupyter-packaging =0.7
   run:
     - jupyter_server >=1.0,<3.0
+    - jupyterlab <4.0
     - python >=3.6,<4.0
     - nbdime >=3.1,<4.0
     - nbformat


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.


This is related to https://github.com/jupyterlab/jupyterlab-git/pull/1249 
and constitutes only an intermediate fix to make a current incompatibility explicit. Please feel free to deny the PR, if you feel it is unnecessary. 

@conda-forge-admin, please rerender
